### PR TITLE
Require ethereumjs-abi 0.6.1 to fix fixed-length array decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ethereumjs-util": "^4.4.0",
     "ethereumjs-tx": "^1.1.1",
     "ethereumjs-account": "^2.0.2",
-    "ethereumjs-abi": "^0.6.0",
+    "ethereumjs-abi": "^0.6.1",
     "web3": "^0.15.3",
     "jquery": "^2.2.0",
     "brace": "^0.8.0",


### PR DESCRIPTION
Fixes https://github.com/chriseth/browser-solidity/issues/156