### PR TITLE
Copy files over to another instance.

### DIFF
--- a/assets/css/browser-solidity.css
+++ b/assets/css/browser-solidity.css
@@ -236,10 +236,11 @@ body {
     padding-left: 6em;
 }
 
-#header #gist {
+#publishView button {
     background-color: #C6CFF7;
     font-size: 12px;
     padding: 0.25em;
+    margin-bottom: .5em;
     color: black;
     border:0 none;
     border-radius: 3px;

--- a/index.html
+++ b/index.html
@@ -91,7 +91,10 @@
 						</div>
 					</div>
 					<div id="publishView">
-						<p><button id="gist" title="Publish all files as public gist on github.com"><i class="fa fa-github"></i> Publish Gist</button> Publish all open files to an anonymous github gist.</p>
+						<p>
+							<button id="gist" title="Publish all files as public gist on github.com"><i class="fa fa-github"></i> Publish Gist</button> Publish all open files to an anonymous github gist.<br/>
+							<button id="copyOver" title="Copy all files to another instance of browser-solidity.">Copy files</button> Copy all files to another instance of browser-solidity.
+						</p>
 						<p>You can also load a gist by adding the following <span class="pre">#gist=GIST_ID</span> to your url, where GIST_ID is the id of the gist to load.</p>
 					</div>
 					<div id="envView">


### PR DESCRIPTION
This PR provides a way to migrate content from one browser-solidity instance to another. It should work across origins and potentially even from `http://` to `file://`, but the latter might vary from browser to browser.

The way it works is that it opens an iframe with the destination and sends the files using `postMessage`.

The danger here lies in the fact that any other website could inject files in that way, origin checking is not done on purpose, to maintain maximal flexibility.