### PR TITLE
Require ethereumjs-vm 1.4.0 to have 'consistent' gas costs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "ethereumjs-block": "^1.2.2",
-    "ethereumjs-vm": "^1.3.0",
+    "ethereumjs-vm": "^1.4.0",
     "merkle-patricia-tree": "^2.1.2",
     "ethereumjs-util": "^4.4.0",
     "ethereumjs-tx": "^1.1.1",

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -21,7 +21,7 @@ function UniversalDApp (contracts, options) {
 
         this.BN = ethJSUtil.BN;
         this.stateTrie = new Trie();
-        this.vm = new EthJSVM(this.stateTrie);
+        this.vm = new EthJSVM(this.stateTrie, null, { activatePrecompiles: true });
 
         this.addAccount('3cd7232cd6f3fc66a57a6bedc1a8ed6c228fff0a327e169c2bcc5e869ed49511')
         this.addAccount('2ac6c190b09897cd8987869cc7b918cfea07ee82038d492abce033c75c1b1d0c')


### PR DESCRIPTION
Don't merge yet - pending ethereumjs-vm release.

The VM is basically always starts in a state similar to *private blockchains*. Precompiled contracts are never transacted with, therefore the first interaction with them will trigger the `callNewAccount` gas fee of 25000.

This patch "activates" all precompiles so that fee won't be triggered by contracts.

Fixes https://github.com/chriseth/browser-solidity/issues/137.