### PR TITLE
Improving imports

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -723,6 +723,9 @@ var run = function() {
 				if (getFiles().indexOf(fileKey(m)) !== -1) {
 					files[m] = window.localStorage[fileKey(m)];
 					reloop = true;
+				} else if (m.startsWith('./') && getFiles().indexOf(fileKey(m.slice(2))) !== -1) {
+					files[m] = window.localStorage[fileKey(m.slice(2))];
+					reloop = true;
 				} else if (m in cachedRemoteFiles) {
 					files[m] = cachedRemoteFiles[m];
 					reloop = true;

--- a/src/app.js
+++ b/src/app.js
@@ -708,7 +708,7 @@ var run = function() {
 			cb(files[fileNameFromKey(SOL_CACHE_FILE)]);
 			return;
 		}
-		var importRegex = /import\s[\'\"]([^\'\"]+)[\'\"];/g;
+		var importRegex = /import\s*[\'\"]([^\'\"]+)[\'\"];/g;
 		var reloop = false;
 		do {
 			reloop = false;

--- a/src/app.js
+++ b/src/app.js
@@ -708,7 +708,7 @@ var run = function() {
 			cb(files[fileNameFromKey(SOL_CACHE_FILE)]);
 			return;
 		}
-		var importRegex = /import\s*[\'\"]([^\'\"]+)[\'\"];/g;
+		var importRegex = /^\s*import\s*[\'\"]([^\'\"]+)[\'\"];/g;
 		var reloop = false;
 		do {
 			reloop = false;


### PR DESCRIPTION
Currently the `importRegex` doesn't match unless there is exactly one space between `import` and `"file.sol"`. If someone put two+ spaces (or zero spaces) between `import` and `"file.sol"`, then the files have to be compiled twice.