### PR TITLE
Looking up libraryName instead of contractName

### DIFF
--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -499,7 +499,7 @@ UniversalDApp.prototype.linkBytecode = function(contractName, cb) {
     if (!m)
         return cb("Invalid bytecode format.");
     var libraryName = m[1];
-    if (!this.getContractByName(contractName))
+    if (!this.getContractByName(libraryName))
         return cb("Library " + libraryName + " not found.");
     var self = this;
     this.deployLibrary(libraryName, function(err, address) {


### PR DESCRIPTION
The code appears to be trying to detect a missing library, but it's actually looking up the name of the contract that's using the library.