### PR TITLE
Consistently display the gas cost (including the 21000 tx fee)

### DIFF
--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -413,7 +413,7 @@ UniversalDApp.prototype.getCallButton = function(args) {
             } else if (self.options.vm){
                 var outputObj = '0x' + result.vm.return.toString('hex');
                 clearOutput($result);
-                $result.append(getReturnOutput(outputObj)).append(getGasUsedOutput(result.vm));
+                $result.append(getReturnOutput(outputObj)).append(getGasUsedOutput(result));
 
                 // Only decode if there supposed to be fields
                 if (args.abi.outputs.length > 0) {


### PR DESCRIPTION
This takes the bugfix commit out of #20.

Fixes https://github.com/chriseth/browser-solidity/issues/137

To clarify:

`result` contains the tx result, which includes a gas cost. Current codes uses `result.vm` which only has the gas cost for the EVM execution and doesn't include the tx fee.

This change makes it to match the behaviour of web3.