### PR TITLE
Safer handling of imports with leading ./

### DIFF
--- a/src/app/compiler.js
+++ b/src/app/compiler.js
@@ -203,7 +203,11 @@ function Compiler (editor, handleGithubCall, outputField, hidingRHP, updateFiles
       for (var fileName in files) {
         var match;
         while ((match = importRegex.exec(files[fileName]))) {
-          importHints.push(match[1]);
+          var importFilePath = match[1];
+          if (importFilePath.startsWith('./')) {
+            importFilePath = importFilePath.slice(2);
+          }
+          importHints.push(importFilePath);
         }
       }
       while (importHints.length > 0) {


### PR DESCRIPTION
The code that allows us to prefix imported files with "./" breaks when you're importing a library. This is because it's being defined twice, which is allowed for contracts. This prevents the double definition.