### PR TITLE
Codestyle formatting (Part 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - stable
-script: npm run build
+script: npm run lint && npm run build
 deploy:
   provider: script
   script: ci/deploy_from_travis.sh

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Minimalistic browser-based Solidity IDE",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "mkdir -p build; browserify src/index.js -o build/app.js"
+    "build": "mkdir -p build; browserify src/index.js -o build/app.js",
+    "lint": "semistandard"
   },
   "devDependencies": {
     "brace": "^0.8.0",
@@ -17,6 +18,7 @@
     "ethereumjs-vm": "^1.4.0",
     "jquery": "^2.2.0",
     "js-base64": "^2.1.9",
+    "semistandard": "^7.0.0",
     "web3": "^0.15.3",
     "webworkify": "^1.2.1"
   },
@@ -35,5 +37,12 @@
     "url": "https://github.com/ethereum/browser-solidity/issues"
   },
   "homepage": "https://github.com/ethereum/browser-solidity#readme",
-  "private": true
+  "private": true,
+  "semistandard": {
+    "ignore": [
+      "assets/js/",
+      "build/",
+      "src/mode-solidity.js"
+    ]
+  }
 }

--- a/src/app/compiler-worker.js
+++ b/src/app/compiler-worker.js
@@ -11,7 +11,7 @@ module.exports = function (self) {
         version = null;
         compileJSON = null;
 
-        importScripts(data.data);
+        self.importScripts(data.data);
         var Module = window.Module;
 
         version = Module.cwrap('version', 'string', []);
@@ -28,7 +28,7 @@ module.exports = function (self) {
         } else {
           compileJSON = Module.cwrap('compileJSON', 'string', ['string', 'number']);
         }
-        postMessage({
+        self.postMessage({
           cmd: 'versionLoaded',
           data: version(),
           acceptsMultipleFiles: ('_compileJSONMulti' in Module)
@@ -36,7 +36,7 @@ module.exports = function (self) {
         break;
       case 'compile':
         missingInputs.length = 0;
-        postMessage({cmd: 'compiled', data: compileJSON(data.source, data.optimize), missingInputs: missingInputs});
+        self.postMessage({cmd: 'compiled', data: compileJSON(data.source, data.optimize), missingInputs: missingInputs});
         break;
     }
   }, false);

--- a/src/app/compiler-worker.js
+++ b/src/app/compiler-worker.js
@@ -7,11 +7,13 @@ module.exports = function (self) {
     var data = e.data;
     switch (data.cmd) {
       case 'loadVersion':
-        delete Module;
+        delete window.Module;
         version = null;
         compileJSON = null;
 
         importScripts(data.data);
+        var Module = window.Module;
+
         version = Module.cwrap('version', 'string', []);
         if ('_compileJSONCallback' in Module) {
           var compileJSONInternal = Module.cwrap('compileJSONCallback', 'string', ['string', 'number', 'number']);

--- a/src/app/compiler.js
+++ b/src/app/compiler.js
@@ -73,6 +73,7 @@ function Compiler (editor, handleGithubCall, outputField, hidingRHP, updateFiles
     if (worker === null) {
       var compile;
       var missingInputs = [];
+      var Module = window.Module;
       if ('_compileJSONCallback' in Module) {
         compilerAcceptsMultipleFiles = true;
         var missingInputsCallback = Module.Runtime.addFunction(function (path, contents, error) {
@@ -146,7 +147,7 @@ function Compiler (editor, handleGithubCall, outputField, hidingRHP, updateFiles
   };
 
   function loadInternal (url, setVersionText) {
-    Module = null;
+    delete window.Module;
     // Set a safe fallback until the new one is loaded
     compileJSON = function (source, optimize) { compilationFinished('{}'); };
 
@@ -155,7 +156,7 @@ function Compiler (editor, handleGithubCall, outputField, hidingRHP, updateFiles
     newScript.src = url;
     document.getElementsByTagName('head')[0].appendChild(newScript);
     var check = window.setInterval(function () {
-      if (!Module) {
+      if (!window.Module) {
         return;
       }
       window.clearInterval(check);

--- a/src/app/execution-context.js
+++ b/src/app/execution-context.js
@@ -5,8 +5,9 @@ var Web3 = require('web3');
 
 var injectedProvider;
 
-if (typeof web3 !== 'undefined') {
-  injectedProvider = web3.currentProvider;
+var web3;
+if (typeof window.web3 !== 'undefined') {
+  injectedProvider = window.web3.currentProvider;
   web3 = new Web3(injectedProvider);
 } else {
   web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));

--- a/src/app/storage-handler.js
+++ b/src/app/storage-handler.js
@@ -1,4 +1,4 @@
-/* global chrome, confirm, localStorage */
+/* global chrome, confirm */
 
 var utils = require('./utils');
 
@@ -17,11 +17,11 @@ function StorageHandler (updateFiles) {
         console.log('comparing to cloud', key, resp);
         if (typeof resp[key] !== 'undefined' && obj[key] !== resp[key] && confirm('Overwrite "' + utils.fileNameFromKey(key) + '"? Click Ok to overwrite local file with file from cloud. Cancel will push your local file to the cloud.')) {
           console.log('Overwriting', key);
-          localStorage.setItem(key, resp[key]);
+          window.localStorage.setItem(key, resp[key]);
           updateFiles();
         } else {
           console.log('add to obj', obj, key);
-          obj[key] = localStorage[key];
+          obj[key] = window.localStorage[key];
         }
         done++;
         if (done >= count) {


### PR DESCRIPTION
Follow up of #68 (and that must be applied first). Adds `npm run lint` test to packages.json and has the more delicate commits regarding globals (Module and web3).

Todo: include the test in Travis so that future PRs are validated.

We could switch over to `standard` from `semistandard` either in this or a subsequent PR to keep diffs digestable.
