### PR TITLE
Suppress displaying the file prefix for compiler errors

### DIFF
--- a/src/app/compiler.js
+++ b/src/app/compiler.js
@@ -45,7 +45,7 @@ function Compiler (editor, handleGithubCall, outputField, hidingRHP, updateFiles
     editor.setCacheFileContent(input);
 
     var files = {};
-    files[editor.getCacheFile()] = input;
+    files[utils.fileNameFromKey(editor.getCacheFile())] = input;
     gatherImports(files, missingInputs, function (input, error) {
       outputField.empty();
       if (input === null) {


### PR DESCRIPTION
This should fix #95.