### PR TITLE
Update browser-solidity.css

### DIFF
--- a/assets/css/browser-solidity.css
+++ b/assets/css/browser-solidity.css
@@ -389,7 +389,7 @@ body {
 #dragbar {
     background-color: transparent;
     position: absolute;
-    width: 1em;
+    width: 0.5em;
     right: -3px;
     top: 3em;
     bottom: 0;


### PR DESCRIPTION
On Firefox the element with "dragbar" ID covers 90% of the element with "input" ID scroll bar. So it is really hard to drag the scroll bar.
I recommend to change in the #dragbar CSS element the Width from 1em to 0.5em.