### PR TITLE
Having another go at stable in-browser testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_script:
   - npm run serve &
 script:
-  - npm run lint && npm run test && npm run build && nightwatch --env chrome
+  - npm run lint && npm run test && npm run build && nightwatch --env remote
   - pkill node
 addons:
   sauce_connect:

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ To run the Selenium tests via nightwatch serve the app through a local web serve
 
 Then you will need to either:
 
- 1. Have a Selenium server running locally on port 4444 along with the chromedriver installed.
+ 1. Have a Selenium server running locally on port 4444.
   * Run: `./node_modules/nightwatch/bin/nightwatch --env local`
- 1. Or, install SauceConnect and run it locally `sc -u <USERNAME> -k <ACCESS_KEY>` (see .travis.yml for values)
-  * Run: `./node_modules/nightwatch/bin/nightwatch --env chrome`
-
+ 1. Or, install and run SauceConnect.
+  * Run: `sc -u <USERNAME> -k <ACCESS_KEY>` (see .travis.yml for values)
+  * Run: `./node_modules/nightwatch/bin/nightwatch --env remote`
 
 ## Usage as a Chrome Extension
 

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -21,9 +21,9 @@
         "waitForConditionTimeout": 60000
       }
     },
-    "chrome" : {
+    "remote" : {
       "desiredCapabilities": {
-        "browserName": "chrome",
+        "browserName": "firefox",
         "javascriptEnabled": true,
         "acceptSslCerts": true
       }
@@ -33,7 +33,7 @@
       "selenium_port": 4444,
       "selenium_host": "localhost",
       "desiredCapabilities": {
-        "browserName": "chrome",
+        "browserName": "firefox",
         "javascriptEnabled": true,
         "acceptSslCerts": true
       }

--- a/test-browser/new-file-test.js
+++ b/test-browser/new-file-test.js
@@ -2,7 +2,7 @@ module.exports = {
   'New file test': function (browser) {
     browser
       .url('http://127.0.0.1:8080')
-      .waitForElementVisible('.newFile', 5000)
+      .waitForElementVisible('.newFile', 10000)
       .click('.newFile')
       .assert.containsText('.active', 'Untitled')
       .end();

--- a/test-browser/smoke-test.js
+++ b/test-browser/smoke-test.js
@@ -2,7 +2,7 @@ module.exports = {
   'Smoke test': function (browser) {
     browser
       .url('http://127.0.0.1:8080')
-      .waitForElementVisible('#righthand-panel', 5000)
+      .waitForElementVisible('#righthand-panel', 10000)
       .assert.containsText('#righthand-panel', 'Solidity version')
       .end();
   }


### PR DESCRIPTION
Before removing nightwatch from .travis.yml, let's see if it performs better using Firefox.