### PR TITLE
Cache build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ env:
   - COMMIT_AUTHOR="Travis CI"
   - PUSH_REPO="git@github.com:ethereum/browser-solidity.git"
   - FILES_TO_PACKAGE="assets background.js build icon.png index.html manifest.json README.md"
+cache:
+  directories:
+    - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ deploy:
     branch: master
 env:
   global:
-  - ENCRYPTION_LABEL="b5c2730599da"
-  - COMMIT_AUTHOR_EMAIL="chris@ethereum.org"
-  - COMMIT_AUTHOR="Travis CI"
-  - PUSH_REPO="git@github.com:ethereum/browser-solidity.git"
-  - FILES_TO_PACKAGE="assets background.js build icon.png index.html manifest.json README.md"
+    - ENCRYPTION_LABEL="b5c2730599da"
+    - COMMIT_AUTHOR_EMAIL="chris@ethereum.org"
+    - COMMIT_AUTHOR="Travis CI"
+    - PUSH_REPO="git@github.com:ethereum/browser-solidity.git"
+    - FILES_TO_PACKAGE="assets background.js build icon.png index.html manifest.json README.md"
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
This will ensure that Travis caches the node_modules folder between builds. This will ensure faster build times as Travis won't have to do a complete reinstall when calling `npm install` each build.