### PR TITLE
UDapp: don't supply a hardcoded limit to estimageGas, but judge based on the response

### DIFF
--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -635,7 +635,6 @@ UniversalDApp.prototype.runTx = function (data, args, cb) {
       from: self.options.getAddress ? self.options.getAddress() : self.web3.eth.accounts[0],
       to: to,
       data: data,
-      gas: gas,
       value: value
     };
     if (constant && !isConstructor) {
@@ -644,6 +643,10 @@ UniversalDApp.prototype.runTx = function (data, args, cb) {
       self.web3.eth.estimateGas(tx, function (err, resp) {
         if (err) {
           return cb(err, resp);
+        }
+
+        if (resp > gas) {
+          return cb('Gas required exceeds limit: ' + resp);
         }
 
         tx.gas = resp;


### PR DESCRIPTION
This way the actual required gas is displayed and once we have a way to change the gas limit on the UI, the user could change it to the required one.