### PR TITLE
Exclude abstract (interface) contracts from the right hand panel

### DIFF
--- a/assets/css/universal-dapp.css
+++ b/assets/css/universal-dapp.css
@@ -216,6 +216,12 @@
 	width: 21px;
 }
 
+.udapp .contractProperty button:disabled {
+	cursor: not-allowed;
+	background-color: white;
+	border-color: lightgray;
+}
+
 .udapp .contractProperty .call {
 	background-color: #FF8B8B;
 	border-color: #FF8B8B;

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -152,6 +152,12 @@ UniversalDApp.prototype.render = function () {
     self.$el.append(self.getABIInputForm());
   } else {
     for (var c in self.contracts) {
+      // This is an abstract contract. Do not display.
+      // FIXME: maybe have a flag for this in the JSON?
+      if (self.contracts[c].bytecode.length === 0) {
+        continue;
+      }
+
       var $contractEl = $('<div class="contract"/>');
 
       if (self.contracts[c].address) {

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -216,11 +216,19 @@ UniversalDApp.prototype.getCreateInterface = function ($container, contract) {
   var $atButton = $('<button class="atAddress"/>').text('At Address').click(function () { self.clickContractAt(self, $container.find('.createContract'), contract); });
   $createInterface.append($atButton);
 
+  var $newButton = self.getInstanceInterface(contract);
+  $createInterface.append($newButton);
+
   // Only display creation interface for non-abstract contracts.
   // FIXME: maybe have a flag for this in the JSON?
-  if (contract.bytecode.length !== 0) {
-    var $newButton = self.getInstanceInterface(contract);
-    $createInterface.append($newButton);
+  // FIXME: maybe fix getInstanceInterface() below for this case
+  if (contract.bytecode.length === 0) {
+    var $createButton = $newButton.find('.constructor .call');
+
+    // NOTE: we must show the button to have CSS properly lined up
+    $createButton.text('Create');
+    $createButton.attr('disabled', 'disabled');
+    $createButton.attr('title', 'This contract does not implement all functions and thus cannot be created.');
   }
 
   return $createInterface;

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -161,13 +161,7 @@ UniversalDApp.prototype.render = function () {
         if (self.contracts[c].bytecode) {
           $title.append($('<div class="size"/>').text((self.contracts[c].bytecode.length / 2) + ' bytes'));
         }
-        $contractEl.append($title);
-
-        // Only display creation interface for non-abstract contracts.
-        // FIXME: maybe have a flag for this in the JSON?
-        if (self.contracts[c].bytecode.length !== 0) {
-          $contractEl.append(self.getCreateInterface($contractEl, self.contracts[c]));
-        }
+        $contractEl.append($title).append(self.getCreateInterface($contractEl, self.contracts[c]));
       }
       self.$el.append(self.renderOutputModifier(self.contracts[c].name, $contractEl));
     }
@@ -219,9 +213,16 @@ UniversalDApp.prototype.getCreateInterface = function ($container, contract) {
     $close.click(function () { self.$el.remove(); });
     $createInterface.append($close);
   }
-  var $newButton = self.getInstanceInterface(contract);
   var $atButton = $('<button class="atAddress"/>').text('At Address').click(function () { self.clickContractAt(self, $container.find('.createContract'), contract); });
-  $createInterface.append($atButton).append($newButton);
+  $createInterface.append($atButton);
+
+  // Only display creation interface for non-abstract contracts.
+  // FIXME: maybe have a flag for this in the JSON?
+  if (contract.bytecode.length !== 0) {
+    var $newButton = self.getInstanceInterface(contract);
+    $createInterface.append($newButton);
+  }
+
   return $createInterface;
 };
 

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -152,12 +152,6 @@ UniversalDApp.prototype.render = function () {
     self.$el.append(self.getABIInputForm());
   } else {
     for (var c in self.contracts) {
-      // This is an abstract contract. Do not display.
-      // FIXME: maybe have a flag for this in the JSON?
-      if (self.contracts[c].bytecode.length === 0) {
-        continue;
-      }
-
       var $contractEl = $('<div class="contract"/>');
 
       if (self.contracts[c].address) {
@@ -167,7 +161,13 @@ UniversalDApp.prototype.render = function () {
         if (self.contracts[c].bytecode) {
           $title.append($('<div class="size"/>').text((self.contracts[c].bytecode.length / 2) + ' bytes'));
         }
-        $contractEl.append($title).append(self.getCreateInterface($contractEl, self.contracts[c]));
+        $contractEl.append($title);
+
+        // Only display creation interface for non-abstract contracts.
+        // FIXME: maybe have a flag for this in the JSON?
+        if (self.contracts[c].bytecode.length !== 0) {
+          $contractEl.append(self.getCreateInterface($contractEl, self.contracts[c]));
+        }
       }
       self.$el.append(self.renderOutputModifier(self.contracts[c].name, $contractEl));
     }


### PR DESCRIPTION
Fixes https://github.com/chriseth/browser-solidity/issues/77.

The check is to exclude any contract which doesn't have a bytecode.