### PR TITLE
Do not crash if event is not found in the ABI

### DIFF
--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -253,11 +253,12 @@ UniversalDApp.prototype.getInstanceInterface = function (contract, address, $tar
         for (var i in response.vm.logs) {
           // [address, topics, mem]
           var log = response.vm.logs[i];
-          var abi = eventABI[log[1][0].toString('hex')];
-          var event = abi.event;
+          var event;
           var decoded;
 
           try {
+            var abi = eventABI[log[1][0].toString('hex')];
+            event = abi.event;
             var types = abi.inputs.map(function (item) {
               return item.type;
             });


### PR DESCRIPTION
Fixes https://github.com/ethereum/browser-solidity/issues/180 and https://github.com/ethereum/browser-solidity/issues/115, but only partially. There's no crash, but we need to find a way to get ABI definition for the non-current contract.

Also "fixes" anonymous events.