### PR TITLE
Cleanup compiler load events

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -444,14 +444,10 @@ var run = function () {
     compiler.compile();
   });
 
-  compiler.event.register('compilerLoaded', this, function (context) {
-    compiler.compile();
-    initWithQueryParams();
-  });
-
   compiler.event.register('compilerLoaded', this, function (version) {
     setVersionText(version);
     compiler.compile();
+    initWithQueryParams();
   });
 
   function initWithQueryParams () {

--- a/src/app.js
+++ b/src/app.js
@@ -444,6 +444,10 @@ var run = function () {
     compiler.compile();
   });
 
+  compiler.event.register('loadingCompiler', this, function (url, usingWorker) {
+    setVersionText(usingWorker ? '(loading using worker)' : '(loading)');
+  });
+
   compiler.event.register('compilerLoaded', this, function (version) {
     setVersionText(version);
     compiler.compile();
@@ -472,7 +476,6 @@ var run = function () {
   }
 
   function loadVersion (version) {
-    setVersionText('(loading)');
     queryParams.update({version: version});
     if (window.soljsonReleases !== undefined && window.soljsonReleases[version] !== undefined) {
       version = window.soljsonReleases[version];

--- a/src/app.js
+++ b/src/app.js
@@ -475,7 +475,7 @@ var run = function () {
     $('#version').text(text);
   }
 
-  var loadVersion = function (version) {
+  function loadVersion (version) {
     setVersionText('(loading)');
     queryParams.update({version: version});
     if (window.soljsonReleases !== undefined && window.soljsonReleases[version] !== undefined) {
@@ -496,7 +496,7 @@ var run = function () {
     } else {
       compiler.loadVersion(false, url);
     }
-  };
+  }
 
   document.querySelector('#optimize').addEventListener('change', function () {
     queryParams.update({ optimize: document.querySelector('#optimize').checked });

--- a/src/app/compiler-worker.js
+++ b/src/app/compiler-worker.js
@@ -9,6 +9,9 @@ module.exports = function (self) {
     switch (data.cmd) {
       case 'loadVersion':
         delete self.Module;
+        // NOTE: workaround some browsers?
+        self.Module = undefined;
+
         compileJSON = null;
 
         self.importScripts(data.data);

--- a/src/app/compiler.js
+++ b/src/app/compiler.js
@@ -144,6 +144,9 @@ function Compiler (editor, queryParams, handleGithubCall, updateFiles) {
 
   function loadInternal (url) {
     delete window.Module;
+    // NOTE: workaround some browsers?
+    window.Module = undefined;
+
     // Set a safe fallback until the new one is loaded
     setCompileJSON(function (source, optimize) {
       compilationFinished({error: 'Compiler not yet loaded.'});

--- a/src/app/compiler.js
+++ b/src/app/compiler.js
@@ -133,6 +133,7 @@ function Compiler (editor, queryParams, handleGithubCall, updateFiles) {
 
   this.loadVersion = function (usingWorker, url) {
     console.log('Loading ' + url + ' ' + (usingWorker ? 'with worker' : 'without worker'));
+    self.event.trigger('loadingCompiler', [url, usingWorker]);
 
     if (usingWorker) {
       loadWorker(url);


### PR DESCRIPTION
- emit `loadingCompiler` event (and display if loading using worker)
- fix bug of compiling twice after version change
- use `compilerLoaded` event for version display
- **workaround broken compiler unloading in some cases**