### PR TITLE
Workaround some browsers which don't tell the error when disconnected

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -413,7 +413,8 @@ var run = function () {
         }
       })
       .fail(function (xhr, text, err) {
-        cb(err);
+        // NOTE: on some browsers, err equals to '' for certain errors (such as offline browser)
+        cb(err || 'Unknown transport error');
       });
   }
 


### PR DESCRIPTION
This bug results in a loop (and out of stack error) when doing a github import while disconnected.