### PR TITLE
Split runTx (and make settings async)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "node test/index.js"
   },
   "devDependencies": {
+    "async": "^2.1.2",
     "babel-cli": "^6.16.0",
     "babel-plugin-transform-es2015-block-scoping": "^6.15.0",
     "babel-plugin-transform-es2015-template-literals": "^6.8.0",

--- a/src/app/renderer.js
+++ b/src/app/renderer.js
@@ -113,14 +113,22 @@ Renderer.prototype.contracts = function (data, source) {
     return source.sources[currentFile]
   }
 
-  var getAddress = function () { return $('#txorigin').val() }
-
-  var getValue = function () {
-    var comp = $('#value').val().split(' ')
-    return self.executionContext.web3().toWei(comp[0], comp.slice(1).join(' '))
+  var getAddress = function (cb) {
+    cb(null, $('#txorigin').val())
   }
 
-  var getGasLimit = function () { return $('#gasLimit').val() }
+  var getValue = function (cb) {
+    try {
+      var comp = $('#value').val().split(' ')
+      cb(null, self.executionContext.web3().toWei(comp[0], comp.slice(1).join(' ')))
+    } catch (e) {
+      cb(e)
+    }
+  }
+
+  var getGasLimit = function (cb) {
+    cb(null, $('#gasLimit').val())
+  }
 
   this.udapp.reset(udappContracts, getAddress, getValue, getGasLimit, renderOutputModifier)
 

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -723,12 +723,21 @@ UniversalDApp.prototype.runTx = function (args, cb) {
       // NOTE: getAddress should be async
       if (self.getAddress) {
         tx.from = self.getAddress()
-      } else if (self.executionContext.isVM()) {
-        tx.from = Object.keys(self.accounts)[0]
+        callback()
       } else {
-        tx.from = self.web3.eth.accounts[0]
+        self.getAccounts(function (err, ret) {
+          if (err) {
+            return callback(err)
+          }
+
+          if (ret.length === 0) {
+            return callback('No accounts available')
+          }
+
+          tx.from = ret[0]
+          callback()
+        })
       }
-      callback()
     },
     // run transaction
     function (callback) {

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -690,14 +690,15 @@ UniversalDApp.prototype.runTx = function (args, cb) {
     function (callback) {
       tx.gasLimit = 3000000
 
-      // NOTE: getGasLimit should be async
       if (self.getGasLimit) {
-        try {
-          tx.gasLimit = self.getGasLimit()
+        self.getGasLimit(function (err, ret) {
+          if (err) {
+            return callback(err)
+          }
+
+          tx.gasLimit = ret
           callback()
-        } catch (e) {
-          callback(e)
-        }
+        })
       } else {
         callback()
       }
@@ -706,24 +707,30 @@ UniversalDApp.prototype.runTx = function (args, cb) {
     function (callback) {
       tx.value = 0
 
-      // NOTE: getValue should be async
       if (self.getValue) {
-        try {
-          tx.value = self.getValue()
+        self.getValue(function (err, ret) {
+          if (err) {
+            return callback(err)
+          }
+
+          tx.value = ret
           callback()
-        } catch (e) {
-          callback(e)
-        }
+        })
       } else {
         callback()
       }
     },
     // query address
     function (callback) {
-      // NOTE: getAddress should be async
       if (self.getAddress) {
-        tx.from = self.getAddress()
-        callback()
+        self.getAddress(function (err, ret) {
+          if (err) {
+            return callback(err)
+          }
+
+          tx.from = ret
+          callback()
+        })
       } else {
         self.getAccounts(function (err, ret) {
           if (err) {

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -741,6 +741,9 @@ UniversalDApp.prototype.runTx = function (args, cb) {
     try {
       var address = self.getAddress ? self.getAddress() : Object.keys(self.accounts)[0]
       var account = self.accounts[address]
+      if (!account) {
+        return cb('Invalid account selected')
+      }
       tx = new EthJSTX({
         nonce: new BN(account.nonce++),
         gasPrice: new BN(1),


### PR DESCRIPTION
This became a monster change set. The core idea is to make the setting inputs asynchronous, so that eventually it can be event driven and/or we can prompt the user which account to send a transaction from.

Fixes two theoretical bugs:
- invalid account is selected in VM mode (not really possible currently as the dropdown is populated by us)
- if personal mode is used in web3, it would still try to use the non-personal account
