### PR TITLE
Fix call result

### DIFF
--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -779,7 +779,16 @@ UniversalDApp.prototype.rawRunTx = function (args, cb) {
     }
     if (args.useCall) {
       tx.gas = gasLimit
-      self.web3.eth.call(tx, cb)
+      var callhash = self.web3.sha3(JSON.stringify(tx))
+      self.web3.eth.call(tx, function (error, result) {
+        if (error) {
+          return cb(error)
+        }
+        cb(null, {
+          result: result,
+          transactionHash: callhash
+        })
+      })
     } else {
       self.web3.eth.estimateGas(tx, function (err, resp) {
         if (err) {


### PR DESCRIPTION
fix https://github.com/ethereum/browser-solidity/issues/334

now debugging a call is deactivated when using web3 (but possible using the Javascript VM), we will need to use the rpc endpoint debug_traceCall (I think this is currently only implemented in the cpp client).