### PR TITLE
Support importing Swarm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "nightwatch": "^0.9.3",
     "solc": "https://github.com/ethereum/solc-js",
     "standard": "^8.5.0",
+    "swarmgw": "^0.1.0",
     "tape": "^4.5.1",
     "web3": "^0.18.0",
     "webworkify": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "nightwatch": "^0.9.3",
     "solc": "https://github.com/ethereum/solc-js",
     "standard": "^8.5.0",
-    "swarmgw": "^0.1.0",
+    "swarmgw": "^0.2.0",
     "tape": "^4.5.1",
     "web3": "^0.18.0",
     "webworkify": "^1.2.1",

--- a/src/app.js
+++ b/src/app.js
@@ -531,7 +531,7 @@ var run = function () {
         files.addReadOnly(url, content)
         cb(null, content)
       })
-    } else if ((match = /^bzzr:\/\/?([0-9a-fA-F]{64}$)/.exec(url))) {
+    } else if ((match = /^(bzzr?:\/\/?.*)$/.exec(url))) {
       $('#output').append($('<div/>').append($('<pre/>').text('Loading ' + url + ' ...')))
       swarmgw.get(match[1], function (err, content) {
         if (err) {

--- a/src/app.js
+++ b/src/app.js
@@ -542,7 +542,8 @@ var run = function () {
         files.addReadOnly(url, content)
         cb(null, content)
       })
-    } else if ((match = /^(bzzr?:\/\/?.*)$/.exec(url))) {
+    } else if ((match = /^(bzz[ri]?:\/\/?.*)$/.exec(url))) {
+      // Supported: bzz:, bzzr:, bzzi:
       $('#output').append($('<div/>').append($('<pre/>').text('Loading ' + url + ' ...')))
       handleSwarmImport(match[1], function (err, content) {
         if (err) {


### PR DESCRIPTION
Implements #356 / #357. Depends on #366.

This requires CORS enabled on swarm-gateways.net, which is in progress (https://github.com/ethereum/go-ethereum/issues/3350).