### PR TITLE
Storage reworked

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -369,7 +369,6 @@ var run = function () {
 
   // ----------------- resizeable ui ---------------
 
-  var EDITOR_SIZE_KEY = 'editor-size-cache'
   var EDITOR_WINDOW_SIZE = 'editorWindowSize'
 
   var dragging = false
@@ -412,14 +411,6 @@ var run = function () {
       reAdjust()
     }
   })
-
-  // convert old browser-solidity
-  if (storage.exists(EDITOR_SIZE_KEY)) {
-    if (!config.exists(EDITOR_WINDOW_SIZE)) {
-      config.set(EDITOR_WINDOW_SIZE, storage.get(EDITOR_SIZE_KEY))
-    }
-    storage.remove(EDITOR_SIZE_KEY)
-  }
 
   if (config.exists(EDITOR_WINDOW_SIZE)) {
     setEditorSize(config.get(EDITOR_WINDOW_SIZE))

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -1,8 +1,6 @@
 'use strict'
 
-var utils = require('./utils')
-
-var CONFIG_FILE = utils.fileKey('.browser-solidity.json')
+var CONFIG_FILE = '.browser-solidity.json'
 
 function Config (storage) {
   this.items = {}

--- a/src/app/debugger.js
+++ b/src/app/debugger.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var remix = require('ethereum-remix')
-var utils = require('./utils')
 var ace = require('brace')
 var Range = ace.acequire('ace/range').Range
 
@@ -70,7 +69,7 @@ Debugger.prototype.debug = function (txHash) {
  * @param {Object} rawLocation - raw position of the source code to hightlight {start, length, file, jump}
  */
 Debugger.prototype.highlight = function (lineColumnPos, rawLocation) {
-  var name = utils.fileNameFromKey(this.editor.getCacheFile()) // current opened tab
+  var name = this.editor.getCacheFile() // current opened tab
   var source = this.compiler.lastCompilationResult.data.sourceList[rawLocation.file] // auto switch to that tab
   this.removeCurrentMarker()
   if (name !== source) {

--- a/src/app/editor.js
+++ b/src/app/editor.js
@@ -1,14 +1,13 @@
 /* global FileReader */
 'use strict'
 
-var utils = require('./utils')
 var examples = require('./example-contracts')
 
 var ace = require('brace')
 require('../mode-solidity.js')
 
 function Editor (loadingFromGist, storage) {
-  var SOL_CACHE_UNTITLED = utils.fileKey('Untitled')
+  var SOL_CACHE_UNTITLED = 'Untitled'
   var SOL_CACHE_FILE = null
 
   var editor = ace.edit('input')
@@ -37,7 +36,7 @@ function Editor (loadingFromGist, storage) {
 
   this.uploadFile = function (file, callback) {
     var fileReader = new FileReader()
-    var cacheName = utils.fileKey(file.name)
+    var cacheName = file.name
 
     fileReader.onload = function (e) {
       storage.set(cacheName, e.target.result)
@@ -85,18 +84,18 @@ function Editor (loadingFromGist, storage) {
   }
 
   this.hasFile = function (name) {
-    return this.getFiles().indexOf(utils.fileKey(name)) !== -1
+    return this.getFiles().indexOf(name) !== -1
   }
 
   this.getFile = function (name) {
-    return storage.get(utils.fileKey(name))
+    return storage.get(name)
   }
 
   function getFiles () {
     var files = []
     storage.keys().forEach(function (f) {
       // NOTE: as a temporary measure do not show the config file in the editor
-      if (utils.isCachedFile(f) && (f !== (utils.fileKey('.browser-solidity.json')))) {
+      if (f !== '.browser-solidity.json') {
         files.push(f)
         if (!sessions[f]) sessions[f] = newEditorSession(f)
       }
@@ -110,7 +109,7 @@ function Editor (loadingFromGist, storage) {
     var filesArr = this.getFiles()
 
     for (var f in filesArr) {
-      files[utils.fileNameFromKey(filesArr[f])] = {
+      files[filesArr[f]] = {
         content: storage.get(filesArr[f])
       }
     }
@@ -174,8 +173,8 @@ function Editor (loadingFromGist, storage) {
   function setupStuff (files) {
     if (files.length === 0) {
       if (loadingFromGist) return
-      files.push(utils.fileKey(examples.ballot.name))
-      storage.set(utils.fileKey(examples.ballot.name), examples.ballot.content)
+      files.push(examples.ballot.name)
+      storage.set(examples.ballot.name, examples.ballot.content)
     }
 
     SOL_CACHE_FILE = files[0]

--- a/src/app/renderer.js
+++ b/src/app/renderer.js
@@ -55,7 +55,7 @@ Renderer.prototype.error = function (message, container, options) {
     var errFile = err[1]
     var errLine = parseInt(err[2], 10) - 1
     var errCol = err[4] ? parseInt(err[4], 10) : 0
-    if (!opt.noAnnotations && (errFile === '' || errFile === utils.fileNameFromKey(self.editor.getCacheFile()))) {
+    if (!opt.noAnnotations && (errFile === '' || errFile === self.editor.getCacheFile())) {
       self.editor.addAnnotation({
         row: errLine,
         column: errCol,
@@ -64,9 +64,9 @@ Renderer.prototype.error = function (message, container, options) {
       })
     }
     $error.click(function (ev) {
-      if (errFile !== '' && errFile !== utils.fileNameFromKey(self.editor.getCacheFile()) && self.editor.hasFile(errFile)) {
+      if (errFile !== '' && errFile !== self.editor.getCacheFile() && self.editor.hasFile(errFile)) {
         // Switch to file
-        self.editor.setCacheFile(utils.fileKey(errFile))
+        self.editor.setCacheFile(errFile)
         self.updateFiles()
       }
       self.editor.handleErrorClick(errLine, errCol)
@@ -287,7 +287,7 @@ Renderer.prototype.contracts = function (data, source) {
   var self = this
 
   var getSource = function (contractName, source, data) {
-    var currentFile = utils.fileNameFromKey(self.editor.getCacheFile())
+    var currentFile = self.editor.getCacheFile()
     return source.sources[currentFile]
   }
 

--- a/src/app/storage.js
+++ b/src/app/storage.js
@@ -19,7 +19,7 @@ function Storage () {
   }
 
   this.keys = function () {
-    return safeKeys().filter(function (item) { return item.replace('sol:', '') })
+    return safeKeys().filter(function (item) { return item.replace(/^\.sol:/, '') })
   }
 
   this.remove = function (name) {
@@ -45,7 +45,7 @@ function Storage () {
   safeKeys().forEach(function (name) {
     if (name.indexOf('sol-cache-file-', 0) === 0) {
       var content = window.localStorage.getItem(name)
-      window.localStorage.setItem('sol:' + name.replace('sol-cache-file-', ''), content)
+      window.localStorage.setItem(name.replace(/^sol-cache-file-/, 'sol:'), content)
       window.localStorage.removeItem(name)
     }
   })

--- a/src/app/storage.js
+++ b/src/app/storage.js
@@ -49,6 +49,9 @@ function Storage () {
       window.localStorage.removeItem(name)
     }
   })
+
+  // remove obsolete key
+  window.localStorage.removeItem('editor-size-cache')
 }
 
 module.exports = Storage

--- a/src/app/storage.js
+++ b/src/app/storage.js
@@ -6,20 +6,24 @@ function Storage () {
   }
 
   this.get = function (name) {
-    return window.localStorage.getItem(name)
+    return window.localStorage.getItem('sol:' + name)
   }
 
   this.set = function (name, content) {
-    window.localStorage.setItem(name, content)
+    window.localStorage.setItem('sol:' + name, content)
   }
 
-  this.keys = function () {
+  function safeKeys () {
     // NOTE: this is a workaround for some browsers
     return Object.keys(window.localStorage).filter(function (item) { return item !== null && item !== undefined })
   }
 
+  this.keys = function () {
+    return safeKeys().filter(function (item) { return item.replace('sol:', '') })
+  }
+
   this.remove = function (name) {
-    window.localStorage.removeItem(name)
+    window.localStorage.removeItem('sol:' + name)
   }
 
   this.rename = function (originalName, newName) {
@@ -36,6 +40,15 @@ function Storage () {
     }
     this.set(filename, content)
   }
+
+  // on startup, upgrade the old storage layout
+  safeKeys().forEach(function (name) {
+    if (name.indexOf('sol-cache-file-', 0) === 0) {
+      var content = window.localStorage.getItem(name)
+      window.localStorage.setItem('sol:' + name.replace('sol-cache-file-', ''), content)
+      window.localStorage.removeItem(name)
+    }
+  })
 }
 
 module.exports = Storage

--- a/src/app/storage.js
+++ b/src/app/storage.js
@@ -19,7 +19,11 @@ function Storage () {
   }
 
   this.keys = function () {
-    return safeKeys().filter(function (item) { return item.replace(/^\.sol:/, '') })
+    return safeKeys()
+      // filter any names not including sol:
+      .filter(function (item) { return item.indexOf('sol:', 0) === 0 })
+      // remove sol: from filename
+      .map(function (item) { return item.replace(/^sol:/, '') })
   }
 
   this.remove = function (name) {

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -1,30 +1,9 @@
 'use strict'
 
-var SOL_CACHE_FILE_PREFIX = 'sol-cache-file-'
-
-function getCacheFilePrefix () {
-  return SOL_CACHE_FILE_PREFIX
-}
-
-function isCachedFile (name) {
-  return name.indexOf(getCacheFilePrefix(), 0) === 0
-}
-
-function fileKey (name) {
-  return getCacheFilePrefix() + name
-}
-
-function fileNameFromKey (key) {
-  return key.replace(getCacheFilePrefix(), '')
-}
-
 function errortype (message) {
   return message.match(/^(.*:[0-9]*:[0-9]* )?Warning: /) ? 'warning' : 'error'
 }
 
 module.exports = {
-  isCachedFile: isCachedFile,
-  fileKey: fileKey,
-  fileNameFromKey: fileNameFromKey,
   errortype: errortype
 }


### PR DESCRIPTION
This changes the `storage` API to only support files, which have a path and internally prefixes them with `sol:` for `localStorage`.

e.g. `ballot.sol` is stored as `sol:ballot.sol`, while `std/owned.sol` is `sol:std/owned.sol`.

Basically this will remove the need for `utils.fileKey`, `utils.fileNameFromKey`, `utils.isCachedFile` and all the complexity those cause.

Will need to be applied after #367 and #375.

A follow up change will be improving the editor to validate filenames and display a directory structure.