### PR TITLE
Always save before compiling

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -694,10 +694,11 @@ var run = function () {
   })
 
   function runCompiler () {
+    editorSyncFile()
     if (currentFile) {
       var target = currentFile
       var sources = {}
-      sources[target] = editor.get(target)
+      sources[target] = files.get(target)
       compiler.compile(sources, target)
     }
   }

--- a/src/app.js
+++ b/src/app.js
@@ -694,11 +694,11 @@ var run = function () {
   })
 
   function runCompiler () {
-    var files = {}
     if (currentFile) {
       var target = currentFile
-      files[target] = editor.get(currentFile)
-      compiler.compile(files, target)
+      var sources = {}
+      sources[target] = editor.get(target)
+      compiler.compile(sources, target)
     }
   }
 


### PR DESCRIPTION
Needed for further steps (such as sending the entire file list to the compiler or for publishing)