### PR TITLE
editorWindowSize can get negative. RHS bar not usable anymore.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -462,7 +462,7 @@ var run = function () {
       $('#ghostbar').remove()
       $(document).unbind('mousemove')
       dragging = false
-      delta = (delta<50)?50:delta
+      delta = (delta < 50) ? 50 : delta
       setEditorSize(delta)
       config.set(EDITOR_WINDOW_SIZE, delta)
       reAdjust()

--- a/src/app.js
+++ b/src/app.js
@@ -462,6 +462,7 @@ var run = function () {
       $('#ghostbar').remove()
       $(document).unbind('mousemove')
       dragging = false
+      delta = (delta<50)?50:delta
       setEditorSize(delta)
       config.set(EDITOR_WINDOW_SIZE, delta)
       reAdjust()


### PR DESCRIPTION
I you pull your RHS bar smaller and go over the browser window bounds editorWindowSize gets negative. The only way to restore the bar and to make the IDE usable again is to change the local storage directly. 