### PR TITLE
Rename and restructure tabs and content in righthand panel

### DIFF
--- a/assets/css/browser-solidity.css
+++ b/assets/css/browser-solidity.css
@@ -178,8 +178,8 @@ body {
 
 #header #options li {
     float: left;
-    padding: 0.3em 0.6em;
-    font-size: 1em;
+    padding: 0.7em 0.3em;
+    font-size: .9em;
     cursor: pointer;
     background-color: transparent;
     margin-right: 0.5em;
@@ -217,6 +217,10 @@ body {
 }
 
 #header #optionViews.envView #envView {
+    display: block;
+}
+
+#header #optionViews.compilationView #compilationView {
     display: block;
 }
 
@@ -275,6 +279,19 @@ body {
 }
 
 #publishView button {
+    background-color: #C6CFF7;
+    font-size: 12px;
+    padding: 0.25em;
+    margin-bottom: .5em;
+    color: black;
+    border:0 none;
+    border-radius: 3px;
+    width: 8em;
+    margin-right: 1em;
+    cursor: pointer;
+}
+
+#compilationView button {
     background-color: #C6CFF7;
     font-size: 12px;
     padding: 0.25em;
@@ -479,7 +496,7 @@ input[type="file"] {
     position:absolute;
     z-index:20;
     background-color:#F77E79;
-} 
+}
 
 .highlightcode_fullLine {
     position:absolute;
@@ -488,6 +505,6 @@ input[type="file"] {
     opacity: 0.5;
 }
 
-.ace_gutter-cell.ace_breakpoint{ 
+.ace_gutter-cell.ace_breakpoint{
     background-color: #F77E79;
 }

--- a/assets/css/universal-dapp.css
+++ b/assets/css/universal-dapp.css
@@ -1,8 +1,7 @@
 .udapp {
 	padding: 1em;
-	border: 1px dotted #4D5686;
+	margin-bottom: 10px;
 	position: relative;
-	box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
 	box-sizing: border-box;
 	overflow: auto;
 }

--- a/index.html
+++ b/index.html
@@ -55,19 +55,19 @@
 			<div id="header">
 				<div id="menu">
 					<ul id="options">
-						<li class="settingsView active" title="Settings"><i class="fa fa-gear"></i></li>
-						<li class="txView" title="Transaction"><i class="fa fa-send"></i></li>
-						<li class="envView" title="Environment"><i class="fa fa-cube"></i></li>
-						<li class="publishView" title="Publish" ><i class="fa fa-cloud-upload"></i></li>
-						<li class="debugView" title="Debugger"><i class="fa fa-bug"></i></li>
-						<li class="verificationView" title="Formal Verification"><i class="fa fa-check"></i></li>
-						<li class="staticanalysisView" title="Static Analysis"><i class="fa fa-search"></i></li>
-						<li id="helpButton"><a href="https://solidity.readthedocs.org" target="_blank" title="Open Documentation" class="fa fa-question"></a></li>
+						<li class="settingsView active" title="Settings">Settings</li>
+						<li class="publishView" title="Publish" >Files</li>
+						<li class="compilationView" title="Compilation">Contract</li>
+						<li class="txView" title="Transaction">Run</li>
+						<li class="debugView" title="Debugger">Debugger</li>
+						<li class="verificationView" title="Formal Verification">Analysis</li>
+						<li id="helpButton"><a href="https://solidity.readthedocs.org" target="_blank" title="Open Documentation">Docs</a></li>
 					</ul>
 					<img id="solIcon" title="Solidity realtime compiler and runtime" src="assets/img/remix_logo_512x512.svg" alt="Solidity realtime compiler and runtime">
 				</div>
 				<div id="optionViews" class="settingsView">
 					<div id="txView">
+						<div id="output"></div>
 						<div class="crow">
 							<label for="txorigin"><select name="txorigin" id="txorigin"></select> Transaction origin</label>
 						</div>
@@ -80,25 +80,6 @@
 						<div class="crow">
 							<label for="value"><input type="text" id="value" value="0"> Value (e.g. .7 ether or 5 wei, defaults to ether)</label>
 						</div>
-					</div>
-					<div id="settingsView">
-						<div class="version crow"><strong>Solidity version:</strong> <span id="version">(loading)</span></div>
-						<div class="crow">Change to: <select id="versionSelector"></select></div>
-						<div class="crow">
-							<label for="editorWrap"><input id="editorWrap" type="checkbox">Text Wrap</label>
-							<label for="optimize"><input id="optimize" type="checkbox">Enable Optimization</label>
-							<label for="autoCompile"><input id="autoCompile" type="checkbox" checked>Auto Compile</label>
-							<button id="compile" title="Compile source code"><i class="fa fa-cog"></i> Compile</button>
-						</div>
-					</div>
-					<div id="publishView">
-						<p>
-							<button id="gist" title="Publish all files as public gist on github.com"><i class="fa fa-github"></i> Publish Gist</button> Publish all open files to an anonymous github gist.<br/>
-							<button id="copyOver" title="Copy all files to another instance of browser-solidity.">Copy files</button> Copy all files to another instance of browser-solidity.
-						</p>
-						<p>You can also load a gist by adding the following <span class="pre">#gist=GIST_ID</span> to your url, where GIST_ID is the id of the gist to load.</p>
-					</div>
-					<div id="envView">
 						<span id="executionContext">
 							<label for="vm-mode">
 								<input id="vm-mode" type="radio" value="vm" checked name="executionContext">
@@ -113,13 +94,33 @@
 							<label for="web3-mode">
 								<input id="web3-mode" type="radio" value="web3" name="executionContext">
 								<strong>Web3 Provider</strong>
-																<p>Execution environment connects to node at localhost (or via IPC if available), transactions will be sent to the network and can cause loss of money or worse!<br/>
-																<b>If this page is served via https and you access your node via http, it might not work. In this case, try cloning the repository and serving it via http.</b></p>
-								<label for="web3Endpoint">
-									<strong>Web3 Provider Endpoint</strong>: <input type="text" id="web3Endpoint" value="http://localhost:8545">
+								<p>Execution environment connects to node at localhost (or via IPC if available), transactions will be sent to the network and can cause loss of money or worse!<br/>
+									<b>If this page is served via https and you access your node via http, it might not work. In this case, try cloning the repository and serving it via http.</b></p>
+									<label for="web3Endpoint">
+										<strong>Web3 Provider Endpoint</strong>: <input type="text" id="web3Endpoint" value="http://localhost:8545">
+									</label>
 								</label>
-							</label>
-						</span>
+							</span>
+					</div>
+					<div id="compilationView">
+						<div id="contract"></div>
+					</div>
+					<div id="settingsView">
+						<div class="version crow"><strong>Solidity version:</strong> <span id="version">(Loading...)</span></div>
+						<div class="crow">Change to: <select id="versionSelector"></select></div>
+						<div class="crow">
+							<label for="editorWrap"><input id="editorWrap" type="checkbox">Text Wrap</label>
+							<label for="optimize"><input id="optimize" type="checkbox">Enable Optimization</label>
+							<label for="autoCompile"><input id="autoCompile" type="checkbox" checked>Auto Compile</label>
+							<button id="compile" title="Compile source code"><i class="fa fa-cog"></i> Compile</button>
+						</div>
+					</div>
+					<div id="publishView">
+						<p>
+							<button id="gist" title="Publish all files as public gist on github.com"><i class="fa fa-github"></i> Publish Gist</button> Publish all open files to an anonymous github gist.<br/>
+							<button id="copyOver" title="Copy all files to another instance of browser-solidity.">Copy files</button> Copy all files to another instance of browser-solidity.
+						</p>
+						<p>You can also load a gist by adding the following <span class="pre">#gist=GIST_ID</span> to your url, where GIST_ID is the id of the gist to load.</p>
 					</div>
 					<div id="debugView">
 						<div id="debugger" ></div>
@@ -141,7 +142,6 @@
 					</div>
 				</div>
 			</div>
-			<div id="output"></div>
 		</div>
 
 		<script src="build/app.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -679,7 +679,7 @@ var run = function () {
     }
   }
   var staticanalysis = new StaticAnalysis(staticAnalysisAPI, compiler.event)
-  $('#staticanalysisView').append(staticanalysis.render())
+  $('#verificationView').append(staticanalysis.render())
 
   // ----------------- autoCompile -----------------
   var autoCompile = document.querySelector('#autoCompile').checked
@@ -765,7 +765,7 @@ var run = function () {
   })
 
   compiler.event.register('loadingCompiler', this, function (url, usingWorker) {
-    setVersionText(usingWorker ? '(loading using worker)' : '(loading)')
+    setVersionText(usingWorker ? '(loading using worker)' : '(Loading...please, wait a moment)')
   })
 
   compiler.event.register('compilerLoaded', this, function (version) {

--- a/src/app/query-params.js
+++ b/src/app/query-params.js
@@ -30,7 +30,7 @@ function QueryParams (_window) {
     for (var x in keys) {
       currentParams[keys[x]] = params[keys[x]]
     }
-    var queryString = '#'
+    var queryString = '#compilationView'
     var updatedKeys = Object.keys(currentParams)
     for (var y in updatedKeys) {
       queryString += updatedKeys[y] + '=' + currentParams[updatedKeys[y]] + '&'

--- a/src/app/renderer.js
+++ b/src/app/renderer.js
@@ -213,7 +213,6 @@ Renderer.prototype.contracts = function (data, source) {
 
   var detailsOpen = {}
   var getDetails = function (contract, source, contractName) {
-    var button = $('<button>Toggle Details</button>')
     var details = $('<div style="display: none;"/>')
 
     if (contract.metadata) {
@@ -245,14 +244,8 @@ Renderer.prototype.contracts = function (data, source) {
       details.append(preRow('Assembly', formatAssemblyText(contract.assembly, '', source)))
     }
 
-    button.click(function () {
-      detailsOpen[contractName] = !detailsOpen[contractName]
-      details.toggle()
-    })
-    if (detailsOpen[contractName]) {
-      details.show()
-    }
-    return $('<div class="contractDetails"/>').append(button).append(details)
+    details.show()
+    return $('<div class="contractDetails"/>').append(details)
   }
 
   var self = this
@@ -301,7 +294,8 @@ Renderer.prototype.contracts = function (data, source) {
   })
 
   $contractOutput.find('.title').click(function (ev) { $(this).closest('.contract').toggleClass('hide') })
-  $('#output').append($contractOutput)
+  $('#contract').append($contractOutput)
+  document.querySelector('#options .compilationView').click()
   $('.col2 input,textarea').click(function () { this.select() })
 }
 

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -16,7 +16,6 @@ var TxRunner = require('./app/txRunner')
 function UniversalDApp (executionContext, options) {
   this.event = new EventManager()
   var self = this
-
   self.options = options || {}
   self.$el = $('<div class="udapp" />')
   self.personalMode = self.options.personalMode || false
@@ -167,7 +166,6 @@ UniversalDApp.prototype.render = function () {
     }
     self.$el.append(self.renderOutputModifier(self.contracts[c].name, $contractEl))
   }
-
   return self.$el
 }
 


### PR DESCRIPTION
So, first batch of changes on the righthand panel is done. 
* renaming tabs
* merging the content 
  * for example in RUN we now have **transaction + execution**, 
  * in ANALYSIS **verification and static analysis** etc.

NEXT TODOS:
1. what is left for now is to divide CONTRACT tab into 2 parts: static contract part and the part with buttons and legend (this part will go under RUN tab. But in order to do that, we will start building **components** for each of the tabs so we can untangle the CSS, HTML and JS and join them nicely into separate components)
2. After that we can also prepare a little documentation for each tab and save it [Solidity documentation on Github] (http://remix.readthedocs.io/en/latest/) and link to it from the tabs