### PR TITLE
Loading spinner

### DIFF
--- a/assets/css/browser-solidity.css
+++ b/assets/css/browser-solidity.css
@@ -42,20 +42,6 @@ body {
     left: 0;
 }
 
-.loader {
-    border: 16px solid #f3f3f3; /* Light grey */
-    border-top: 16px solid #3498db; /* Blue */
-    border-radius: 50%;
-    width: 120px;
-    height: 120px;
-    animation: spin 2s linear infinite;
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
-
 #tabs-bar {
     position: absolute;
     overflow: hidden;

--- a/assets/css/browser-solidity.css
+++ b/assets/css/browser-solidity.css
@@ -42,6 +42,20 @@ body {
     left: 0;
 }
 
+.loader {
+    border: 16px solid #f3f3f3; /* Light grey */
+    border-top: 16px solid #3498db; /* Blue */
+    border-radius: 50%;
+    width: 120px;
+    height: 120px;
+    animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
 #tabs-bar {
     position: absolute;
     overflow: hidden;

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 						<li class="publishView" title="Publish" >Files</li>
 						<li class="debugView" title="Debugger">Debugger</li>
 						<li class="staticanalysisView" title="Static Analysis">Analysis</li>
-						<li id="helpButton"><a href="https://solidity.readthedocs.org" target="_blank" title="Open Documentation">Docs</a></li>
+						<li id="helpButton"><a href="https://remix.readthedocs.org" target="_blank" title="Open Documentation">Docs</a></li>
 					</ul>
 				</div>
 				<div id="optionViews" class="settingsView">

--- a/index.html
+++ b/index.html
@@ -58,10 +58,10 @@
 					<img id="solIcon" title="Solidity realtime compiler and runtime" src="assets/img/remix_logo_512x512.svg" alt="Solidity realtime compiler and runtime">
 					<ul id="options">
 						<li class="envView" title="Environment">Contract</li>
+						<li class="settingsView" title="Settings">Settings</li>
 						<li class="publishView" title="Publish" >Files</li>
 						<li class="debugView" title="Debugger">Debugger</li>
 						<li class="staticanalysisView" title="Static Analysis">Analysis</li>
-						<li class="settingsView" title="Settings">Settings</li>
 						<li id="helpButton"><a href="https://solidity.readthedocs.org" target="_blank" title="Open Documentation">Docs</a></li>
 					</ul>
 				</div>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 				<div id="menu">
 					<img id="solIcon" title="Solidity realtime compiler and runtime" src="assets/img/remix_logo_512x512.svg" alt="Solidity realtime compiler and runtime">
 					<ul id="options">
-						<li class="envView active" title="Environment">Contract</li>
+						<li class="envView" title="Environment">Contract</li>
 						<li class="publishView" title="Publish" >Files</li>
 						<li class="debugView" title="Debugger">Debugger</li>
 						<li class="staticanalysisView" title="Static Analysis">Analysis</li>

--- a/index.html
+++ b/index.html
@@ -57,11 +57,11 @@
 				<div id="menu">
 					<img id="solIcon" title="Solidity realtime compiler and runtime" src="assets/img/remix_logo_512x512.svg" alt="Solidity realtime compiler and runtime">
 					<ul id="options">
-						<li class="envView" title="Environment">Contract</li>
+						<li class="envView active" title="Environment">Contract</li>
 						<li class="publishView" title="Publish" >Files</li>
 						<li class="debugView" title="Debugger">Debugger</li>
 						<li class="staticanalysisView" title="Static Analysis">Analysis</li>
-						<li class="settingsView active" title="Settings">Settings</li>
+						<li class="settingsView" title="Settings">Settings</li>
 						<li id="helpButton"><a href="https://solidity.readthedocs.org" target="_blank" title="Open Documentation">Docs</a></li>
 					</ul>
 				</div>

--- a/index.html
+++ b/index.html
@@ -57,12 +57,12 @@
 				<div id="menu">
 					<img id="solIcon" title="Solidity realtime compiler and runtime" src="assets/img/remix_logo_512x512.svg" alt="Solidity realtime compiler and runtime">
 					<ul id="options">
-						<li class="settingsView active" title="Settings">Settings</li>
-						<li class="publishView" title="Publish" >Files</li>
 						<li class="envView" title="Environment">Contract</li>
+						<li class="publishView" title="Publish" >Files</li>
 						<li class="debugView" title="Debugger">Debugger</li>
 						<li class="staticanalysisView" title="Static Analysis">Analysis</li>
-						<li id="helpButton"><a href="https://remix.readthedocs.org" target="_blank" title="Open Documentation">Docs</a></li>
+						<li class="settingsView active" title="Settings">Settings</li>
+						<li id="helpButton"><a href="https://solidity.readthedocs.org" target="_blank" title="Open Documentation">Docs</a></li>
 					</ul>
 				</div>
 				<div id="optionViews" class="settingsView">

--- a/src/app/compiler.js
+++ b/src/app/compiler.js
@@ -77,7 +77,6 @@ function Compiler (handleImportCall) {
 
         compilationFinished(result, missingInputs, source)
       }
-
       onCompilerLoaded(compiler.version())
     }
   }

--- a/src/app/loading-spinner.js
+++ b/src/app/loading-spinner.js
@@ -1,0 +1,32 @@
+var yo = require('yo-yo')
+var csjs = require('csjs-inject')
+
+module.exports = loadingSpinner
+
+var css = csjs`
+  .loader {
+    display: inline-block;
+    margin-left: .3em;
+    border: 2px solid #C6CFD9; /* Light grey */
+    border-top: 2px solid #F4F6FF; /* Light blue */
+    border-radius: 50%;
+    width: 8px;
+    height: 8px;
+    animation: spin 2s linear infinite;
+  }
+
+  @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+  }
+`
+function loadingSpinner (cb) {
+  var el = yo`<div class=${css.loader}></div>`
+  if (cb) {
+    cb(function finish () {
+      var p = el.parentElement
+      if (p) p.removeChild(el)
+    })
+  }
+  return el
+}

--- a/src/app/loading-spinner.js
+++ b/src/app/loading-spinner.js
@@ -1,5 +1,8 @@
 var yo = require('yo-yo')
+// -------------- styling ----------------------
 var csjs = require('csjs-inject')
+var styleGuide = require('./style-guide')
+var styles = styleGuide()
 
 module.exports = loadingSpinner
 
@@ -14,7 +17,6 @@ var css = csjs`
     height: 8px;
     animation: spin 2s linear infinite;
   }
-
   @keyframes spin {
       0% { transform: rotate(0deg); }
       100% { transform: rotate(360deg); }
@@ -26,6 +28,9 @@ function loadingSpinner (cb) {
     cb(function finish () {
       var p = el.parentElement
       if (p) p.removeChild(el)
+      var node = document.querySelector('[class^=contractTabView]')
+      var loadingMsg = document.querySelector('[class^=loadingMsg]')
+      node.removeChild(loadingMsg)
     })
   }
   return el

--- a/src/app/loading-spinner.js
+++ b/src/app/loading-spinner.js
@@ -1,8 +1,6 @@
 var yo = require('yo-yo')
 // -------------- styling ----------------------
 var csjs = require('csjs-inject')
-var styleGuide = require('./style-guide')
-var styles = styleGuide()
 
 module.exports = loadingSpinner
 
@@ -22,16 +20,7 @@ var css = csjs`
       100% { transform: rotate(360deg); }
   }
 `
-function loadingSpinner (cb) {
+function loadingSpinner () {
   var el = yo`<div class=${css.loader}></div>`
-  if (cb) {
-    cb(function finish () {
-      var p = el.parentElement
-      if (p) p.removeChild(el)
-      var node = document.querySelector('[class^=contractTabView]')
-      var loadingMsg = document.querySelector('[class^=loadingMsg]')
-      node.removeChild(loadingMsg)
-    })
-  }
   return el
 }

--- a/src/app/style-guide.js
+++ b/src/app/style-guide.js
@@ -74,11 +74,11 @@ function styleGuide () {
     }
 
     .warning-text-box {
-      background-color      : #E6E5A7;  // yellow
+      background-color      : hsla(59, 56%, 78%, 0.5);  // yellow
       line-height           : 20px;
-      padding               : 1em 1em .5em 1em;
-      border-radius         : 3px;
-      box-shadow            : rgba(0,0,0,.2) 0 1px 4px;
+      padding               : 8px 15px;
+      border-radius         : 5px;
+      border                : .2em dotted #ffbd01; // orange-yellow
       margin-bottom         : 1em;
     }
 
@@ -143,6 +143,7 @@ function styleGuide () {
   return {
     textBoxL: textBoxes['display-box-L'],
     infoTextBox: textBoxes['info-text-box'],
+    warningTextBox: textBoxes['warning-text-box'],
     titleL: texts['title-L'],
     titleM: texts['title-M'],
     dropdown: buttons['dropdown-menu'],

--- a/src/app/tabbed-menu.js
+++ b/src/app/tabbed-menu.js
@@ -1,0 +1,48 @@
+var $ = require('jquery')
+
+module.exports = tabbedMenu
+
+function tabbedMenu (compiler, loadingSpinner, self) {
+  $('#options li').click(function (ev) {
+    var $el = $(this)
+    selectTab($el)
+  })
+
+  // initialize tabbed menu
+  selectTab($('#options .envView'))
+
+  // add event listeners for loading spinner
+  // compiler.event.register('compilationStarted', function compilationStarted () {
+  compiler.event.register('loadingCompiler', function compilationStarted () {
+    var contractTab = document.querySelector('.envView')
+    if (!contractTab.children.length) {
+      contractTab.appendChild(loadingSpinner(function cb (finish) {
+        // compiler.event.register('compilationFinished', function () {
+        compiler.event.register('compilerLoaded', finish)
+      }))
+    }
+  })
+  compiler.event.register('loadingCompiler', function loadingCompiler () {
+    var settingsTab = document.querySelector('.settingsView')
+    if (!settingsTab.children.length) {
+      settingsTab.appendChild(loadingSpinner(function cb (finish) {
+        compiler.event.register('compilerLoaded', finish)
+      }))
+    }
+  })
+
+  // select tab
+  function selectTab (el) {
+    var match = /[a-z]+View/.exec(el.get(0).className)
+    if (!match) return
+    var cls = match[0]
+    if (!el.hasClass('active')) {
+      el.get(0).parentElement.querySelectorAll('li').forEach(function (li) {
+        li.classList.remove('active')
+      })
+      $('#optionViews').attr('class', '').addClass(cls)
+      el.addClass('active')
+    }
+    self.event.trigger('tabChanged', [cls])
+  }
+}

--- a/src/app/tabbed-menu.js
+++ b/src/app/tabbed-menu.js
@@ -35,9 +35,7 @@ function tabbedMenu (compiler, loadingSpinner, self) {
     }
     var settingsTab = document.querySelector('.settingsView')
     if (!settingsTab.children.length) {
-      settingsTab.appendChild(loadingSpinner(function cb (finish) {
-        compiler.event.register('compilerLoaded', finish)
-      }))
+      settingsTab.appendChild(loadingSpinner(cb))
     }
   })
 

--- a/src/app/tabbed-menu.js
+++ b/src/app/tabbed-menu.js
@@ -11,18 +11,15 @@ function tabbedMenu (compiler, loadingSpinner, self) {
   // initialize tabbed menu
   selectTab($('#options .envView'))
 
+  function cb (finish) {
+    compiler.event.register('compilerLoaded', finish)
+  }
   // add event listeners for loading spinner
-  // compiler.event.register('compilationStarted', function compilationStarted () {
   compiler.event.register('loadingCompiler', function compilationStarted () {
     var contractTab = document.querySelector('.envView')
     if (!contractTab.children.length) {
-      contractTab.appendChild(loadingSpinner(function cb (finish) {
-        // compiler.event.register('compilationFinished', function () {
-        compiler.event.register('compilerLoaded', finish)
-      }))
+      contractTab.appendChild(loadingSpinner(cb))
     }
-  })
-  compiler.event.register('loadingCompiler', function loadingCompiler () {
     var settingsTab = document.querySelector('.settingsView')
     if (!settingsTab.children.length) {
       settingsTab.appendChild(loadingSpinner(function cb (finish) {

--- a/src/app/tabbed-menu.js
+++ b/src/app/tabbed-menu.js
@@ -22,20 +22,23 @@ function tabbedMenu (compiler, loadingSpinner, self) {
   // initialize tabbed menu
   selectTab($('#options .envView'))
 
-  function cb (finish) {
-    compiler.event.register('compilerLoaded', finish)
-  }
   // add event listeners for loading spinner
-  compiler.event.register('loadingCompiler', function compilationStarted () {
-    var contractTab = document.querySelector('.envView')
-    if (!contractTab.children.length) {
-      var el = document.querySelector('[class^=contractTabView]')
-      var loadingMsg = yo`<div class=${css.loadingMsg}>Solidity compiler is currently loading. Please wait a moment...</div>`
-      el.appendChild(loadingMsg)
-    }
+  compiler.event.register('loadingCompiler', function start () {
     var settingsTab = document.querySelector('.settingsView')
-    if (!settingsTab.children.length) {
-      settingsTab.appendChild(loadingSpinner(cb))
+    if (settingsTab.children.length) return
+
+    var contractTabView = document.querySelector('[class^=contractTabView]')
+
+    var loadingMsg = yo`<div class=${css.loadingMsg}>Solidity compiler is currently loading. Please wait a moment...</div>`
+    var spinner = loadingSpinner()
+    settingsTab.appendChild(spinner)
+    contractTabView.appendChild(loadingMsg)
+
+    compiler.event.register('compilerLoaded', finish)
+    function finish () {
+      compiler.event.unregister('compilerLoaded', finish)
+      contractTabView.removeChild(loadingMsg)
+      settingsTab.removeChild(spinner)
     }
   })
 

--- a/src/app/tabbed-menu.js
+++ b/src/app/tabbed-menu.js
@@ -1,8 +1,19 @@
 var $ = require('jquery')
+var yo = require('yo-yo')
+var csjs = require('csjs-inject')
+var styleGuide = require('./style-guide')
+var styles = styleGuide()
 
 module.exports = tabbedMenu
 
 function tabbedMenu (compiler, loadingSpinner, self) {
+
+  var css = csjs`
+    .loadingMsg extends ${styles.warningTextBox} {
+      display: block;
+    }
+  `
+
   $('#options li').click(function (ev) {
     var $el = $(this)
     selectTab($el)
@@ -18,7 +29,9 @@ function tabbedMenu (compiler, loadingSpinner, self) {
   compiler.event.register('loadingCompiler', function compilationStarted () {
     var contractTab = document.querySelector('.envView')
     if (!contractTab.children.length) {
-      contractTab.appendChild(loadingSpinner(cb))
+      var el = document.querySelector('[class^=contractTabView]')
+      var loadingMsg = yo`<div class=${css.loadingMsg}>Solidity compiler is currently loading. Please wait a moment...</div>`
+      el.appendChild(loadingMsg)
     }
     var settingsTab = document.querySelector('.settingsView')
     if (!settingsTab.children.length) {

--- a/src/lib/eventManager.js
+++ b/src/lib/eventManager.js
@@ -1,0 +1,64 @@
+'use strict'
+
+function eventManager () {
+  this.registered = {}
+}
+
+/*
+   * Unregister a listenner.
+   * Note that if obj is a function. the unregistration will be applied to the dummy obj {}.
+   *
+   * @param {String} eventName  - the event name
+   * @param {Object or Func} obj - object that will listen on this event
+   * @param {Func} func         - function of the listenners that will be executed
+*/
+eventManager.prototype.unregister = function (eventName, obj, func) {
+  if (obj instanceof Function) {
+    func = obj
+    obj = {}
+  }
+  for (var reg in this.registered[eventName]) {
+    if (this.registered[eventName][reg] && (!func || this.registered[eventName][reg].func === func)) {
+      this.registered[eventName].splice(reg, 1)
+      return
+    }
+  }
+}
+
+/*
+   * Register a new listenner.
+   * Note that if obj is a function, the function registration will be associated with the dummy object {}
+   *
+   * @param {String} eventName  - the event name
+   * @param {Object or Func} obj - object that will listen on this event
+   * @param {Func} func         - function of the listenners that will be executed
+*/
+eventManager.prototype.register = function (eventName, obj, func) {
+  if (!this.registered[eventName]) {
+    this.registered[eventName] = []
+  }
+  if (obj instanceof Function) {
+    func = obj
+    obj = {}
+  }
+  this.registered[eventName].push({
+    obj: obj,
+    func: func
+  })
+}
+
+/*
+   * trigger event.
+   * Every listenner have their associated function executed
+   *
+   * @param {String} eventName  - the event name
+   * @param {Array}j - argument that will be passed to the exectued function.
+*/
+eventManager.prototype.trigger = function (eventName, args) {
+  for (var listener in this.registered[eventName]) {
+    var l = this.registered[eventName][listener]
+    l.func.apply(l.obj, args)
+  }
+}
+
+module.exports = eventManager


### PR DESCRIPTION
* Rearange tabs - contract first tab
* Change default tab to contract
* Add loaderSpinner to contract and settings tab

?? Since changing a compiler version is super connected to the contract, maybe we should think about how to elegantly add **change version** to contract tab, maybe above could be settings (all that is there already + current version/change version) and below the contract(s). 
Don't know exactly how, but it's hard for new users to understand that in the settings you change the compiler version and that actually changes the version in all your contracts... Would make sense to put this together somehow...