### PR TITLE
fix encoding params

### DIFF
--- a/src/app/execution/txHelper.js
+++ b/src/app/execution/txHelper.js
@@ -8,6 +8,9 @@ module.exports = {
     if (funABI.inputs && funABI.inputs.length) {
       for (var i = 0; i < funABI.inputs.length; i++) {
         types.push(funABI.inputs[i].type)
+        if (args.length < types.length) {
+          args.push('')
+        }
       }
     }
 


### PR DESCRIPTION
`args` should have the same length as `types`