### PR TITLE
Cap ethereumjs-vm at 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ethereumjs-block": "^1.6.0",
     "ethereumjs-tx": "^1.3.3",
     "ethereumjs-util": "^5.1.2",
-    "ethereumjs-vm": "https://github.com/ethereumjs/ethereumjs-vm",
+    "ethereumjs-vm": "2.2.2",
     "execr": "^1.0.1",
     "exorcist": "^0.4.0",
     "fast-async": "^6.1.2",


### PR DESCRIPTION
EthereumJS-vm master branch is currently broken (in the browser) by the Byzantium changes that were merged today.  The latest npm release should be installed as a dependency until the issue is resolved and a new version of ethereumjs-vm is released