### PR TITLE
[ONLY-TEST] Test build with ethereumjs-vm Byzantium master branch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ethereumjs-block": "^1.6.0",
     "ethereumjs-tx": "^1.3.3",
     "ethereumjs-util": "^5.1.2",
-    "ethereumjs-vm": "2.2.2",
+    "ethereumjs-vm": "https://github.com/ethereumjs/ethereumjs-vm",
     "execr": "^1.0.1",
     "exorcist": "^0.4.0",
     "fast-async": "^6.1.2",


### PR DESCRIPTION
This is just a build test, don't merge.

Testing the build with new ethereumjs-vm version after fixing a critical ``rustbn.js`` bug (https://github.com/ethereumjs/rustbn.js/pull/4) preventing ``browserify`` of the library to work.