### PR TITLE
Example Contract - Fix compiler warnings / reduce static analysis warning

### DIFF
--- a/src/app/editor/example-contracts.js
+++ b/src/app/editor/example-contracts.js
@@ -24,11 +24,11 @@ contract Ballot {
         proposals.length = _numProposals;
     }
 
-    /// Give $(voter) the right to vote on this ballot.
+    /// Give $(toVoter) the right to vote on this ballot.
     /// May only be called by $(chairperson).
-    function giveRightToVote(address voter) public {
-        if (msg.sender != chairperson || voters[voter].voted) return;
-        voters[voter].weight = 1;
+    function giveRightToVote(address toVoter) public {
+        if (msg.sender != chairperson || voters[toVoter].voted) return;
+        voters[toVoter].weight = 1;
     }
 
     /// Delegate your vote to the voter $(to).
@@ -47,21 +47,21 @@ contract Ballot {
             delegateTo.weight += sender.weight;
     }
 
-    /// Give a single vote to proposal $(proposal).
-    function vote(uint8 proposal) public {
+    /// Give a single vote to proposal $(toProposal).
+    function vote(uint8 toProposal) public {
         Voter storage sender = voters[msg.sender];
-        if (sender.voted || proposal >= proposals.length) return;
+        if (sender.voted || toProposal >= proposals.length) return;
         sender.voted = true;
-        sender.vote = proposal;
-        proposals[proposal].voteCount += sender.weight;
+        sender.vote = toProposal;
+        proposals[toProposal].voteCount += sender.weight;
     }
 
     function winningProposal() public constant returns (uint8 _winningProposal) {
         uint256 winningVoteCount = 0;
-        for (uint8 proposal = 0; proposal < proposals.length; proposal++)
-            if (proposals[proposal].voteCount > winningVoteCount) {
-                winningVoteCount = proposals[proposal].voteCount;
-                _winningProposal = proposal;
+        for (uint8 prop = 0; prop < proposals.length; prop++)
+            if (proposals[prop].voteCount > winningVoteCount) {
+                winningVoteCount = proposals[prop].voteCount;
+                _winningProposal = prop;
             }
     }
 }`

--- a/src/app/editor/example-contracts.js
+++ b/src/app/editor/example-contracts.js
@@ -18,7 +18,7 @@ contract Ballot {
     Proposal[] proposals;
 
     /// Create a new ballot with $(_numProposals) different proposals.
-    function Ballot(uint8 _numProposals) {
+    function Ballot(uint8 _numProposals) public {
         chairperson = msg.sender;
         voters[chairperson].weight = 1;
         proposals.length = _numProposals;
@@ -26,13 +26,13 @@ contract Ballot {
 
     /// Give $(voter) the right to vote on this ballot.
     /// May only be called by $(chairperson).
-    function giveRightToVote(address voter) {
+    function giveRightToVote(address voter) public {
         if (msg.sender != chairperson || voters[voter].voted) return;
         voters[voter].weight = 1;
     }
 
     /// Delegate your vote to the voter $(to).
-    function delegate(address to) {
+    function delegate(address to) public {
         Voter storage sender = voters[msg.sender]; // assigns reference
         if (sender.voted) return;
         while (voters[to].delegate != address(0) && voters[to].delegate != msg.sender)
@@ -48,7 +48,7 @@ contract Ballot {
     }
 
     /// Give a single vote to proposal $(proposal).
-    function vote(uint8 proposal) {
+    function vote(uint8 proposal) public {
         Voter storage sender = voters[msg.sender];
         if (sender.voted || proposal >= proposals.length) return;
         sender.voted = true;
@@ -56,7 +56,7 @@ contract Ballot {
         proposals[proposal].voteCount += sender.weight;
     }
 
-    function winningProposal() constant returns (uint8 _winningProposal) {
+    function winningProposal() public constant returns (uint8 _winningProposal) {
         uint256 winningVoteCount = 0;
         for (uint8 proposal = 0; proposal < proposals.length; proposal++)
             if (proposals[proposal].voteCount > winningVoteCount) {


### PR DESCRIPTION
This PR fixes the initial compiler warnings for the example contract by setting the visibility values for functions to the default (``public``) and choose slightly different names for some variables static analysis is complaining about.

This should reduce irritation to new users being directly confronted with various warnings after example compilation.

Tested locally with cache cleared.