### PR TITLE
Don't run blockgaslimit update requests on provider set to vm

### DIFF
--- a/src/execution-context.js
+++ b/src/execution-context.js
@@ -147,14 +147,16 @@ function ExecutionContext () {
   this.blockGasLimitDefault = 4300000
   this.blockGasLimit = this.blockGasLimitDefault
   setInterval(() => {
-    web3.eth.getBlock('latest', (err, block) => {
-      if (!err) {
-        // we can't use the blockGasLimit cause the next blocks could have a lower limit : https://github.com/ethereum/remix/issues/506
-        this.blockGasLimit = (block && block.gasLimit) ? Math.floor(block.gasLimit - (5 * block.gasLimit) / 1024) : this.blockGasLimitDefault
-      } else {
-        this.blockGasLimit = this.blockGasLimitDefault
-      }
-    })
+    if (this.getProvider() !== 'vm') {
+      web3.eth.getBlock('latest', (err, block) => {
+        if (!err) {
+          // we can't use the blockGasLimit cause the next blocks could have a lower limit : https://github.com/ethereum/remix/issues/506
+          this.blockGasLimit = (block && block.gasLimit) ? Math.floor(block.gasLimit - (5 * block.gasLimit) / 1024) : this.blockGasLimitDefault
+        } else {
+          this.blockGasLimit = this.blockGasLimitDefault
+        }
+      })
+    }
   }, 15000)
 
   function setProviderFromEndpoint (endpoint) {


### PR DESCRIPTION
This prevents constant request error output on the console when using ``vm`` as a provider.

Tested both the new negative ``vm`` case as well as the positive (still requesting) ``injected`` case with MetaMask.

