### PR TITLE
Remove needless enclosing div tag

### DIFF
--- a/src/app/panels/terminal.js
+++ b/src/app/panels/terminal.js
@@ -209,7 +209,7 @@ class Terminal {
             <i class="fa fa-ban" aria-hidden="true" onmouseenter=${hover} onmouseleave=${hover}></i>
           </div>
           ${self._view.dropdown}
-          <input type="text" class=${css.filter} onkeyup=${filter}></div>
+          <input type="text" class=${css.filter} onkeyup=${filter}>
           <input onchange=${listenOnNetwork} type="checkbox" /><label title="If checked Remix will listen on all transactions mined in the current environment and not only transactions created from the GUI">Listen on network</label>
           ${self._view.icon}
         </div>


### PR DESCRIPTION
Hi! I deleted the div tag because I found it in the following error.
`multiple root elements must be wrapped in an enclosing tag`
TravisCI also fell with the same error 😢 
https://travis-ci.org/ethereum/browser-solidity/builds/282985894

The following is my environments :)
### Error message
```
Error: /Users/kurotaky/ghq/github.com/ethereum/browser-solidity/src/app/panels/terminal.js: multiple root elements must be wrapped in an enclosing tag
```

### OS
```
ProductName:	Mac OS X
ProductVersion:	10.11.6
BuildVersion:	15G1611
```

### node --version
```
v8.1.3
```

### npm version
```
4.6.1
```