### PR TITLE
upgrade ethereumjs-vm version to byzantium

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ethereumjs-block": "^1.6.0",
     "ethereumjs-tx": "^1.3.3",
     "ethereumjs-util": "^5.1.2",
-    "ethereumjs-vm": "2.2.2",
+    "ethereumjs-vm": "2.3.1",
     "execr": "^1.0.1",
     "exorcist": "^0.4.0",
     "fast-async": "^6.1.2",


### PR DESCRIPTION
Updates ethereumjs-vm to dependency to 2.3.1 in order to include Byzantium support.