### PR TITLE
Fix critical bug using Ether as base unit for value input / add some context help

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -215,7 +215,13 @@ function run () {
     getValue: (cb) => {
       try {
         var comp = $('#value').val().split(' ')
-        cb(null, executionContext.web3().toWei(comp[0], comp.slice(1).join(' ')))
+        if (comp.length === 1) {
+          cb(null, comp[0])
+        } else if (comp.length === 2) {
+          cb(null, executionContext.web3().toWei(comp[0], comp.slice(1).join(' ')))
+        } else {
+          cb(new Error('Value has the wrong format!'))
+        }
       } catch (e) {
         cb(e)
       }

--- a/src/app/tabs/run-tab.js
+++ b/src/app/tabs/run-tab.js
@@ -413,7 +413,7 @@ function settings (appAPI, appEvents) {
       </div>
       <div class="${css.crow}">
       <div class="${css.col1_1}">Value</div>
-        <input type="text" class="${css.col2}" id="value" value="0" title="(e.g. .7 ether ...)">
+        <input type="text" class="${css.col2}" id="value" value="0" title="Examples: 5 ether, 100 wei, 40 (base unit: wei)">
       </div>
     </div>
   `

--- a/src/app/tabs/run-tab.js
+++ b/src/app/tabs/run-tab.js
@@ -376,7 +376,7 @@ function settings (appAPI, appEvents) {
         <div id="selectExEnv" class="${css.col1_1}">
           Environment
         </div>
-        <select id="selectExEnvOptions" class="${css.select}">
+        <select id="selectExEnvOptions" class="${css.select}" title="Run your contract in a simulated environment (JavaScript VM) or connect to an actual Ethereum network.">
           <option id="vm-mode"
             title="Execution environment does not connect to any node, everything is local and in memory only."
             value="vm"
@@ -384,7 +384,7 @@ function settings (appAPI, appEvents) {
             JavaScript VM
           </option>
           <option id="injected-mode"
-            title="Execution environment has been provided by Mist or similar provider."
+            title="Execution environment has been provided by MetaMask or similar provider."
             value="injected"
             checked name="executionContext">
             Injected Web3
@@ -400,16 +400,16 @@ function settings (appAPI, appEvents) {
       </div>
       <div class="${css.crow}">
         <div class="${css.col1_1}">Account</div>
-        <select name="txorigin" class="${css.select}" id="txorigin"></select>
+        <select name="txorigin" class="${css.select}" id="txorigin" title="Dummy accounts provided with some ether (JavaScript VM), otherwise the accounts set up in your connected environment (handle with care!)."></select>
         <i title="Copy Address" class="copytxorigin fa fa-clipboard ${css.copyaddress}" onclick=${copyAddress} aria-hidden="true"></i>
       </div>
       <div class="${css.crow}">
         <div class="${css.col1_1}">Gas limit</div>
-        <input type="number" class="${css.col2}" id="gasLimit" value="3000000">
+        <input type="number" class="${css.col2}" id="gasLimit" value="3000000" title="Gas limit for contract creation and execution. Set this high in simulated environment, otherwise appropriate to contract needs (see gas estimates in compile details view for orientation).">
       </div>
       <div class="${css.crow} hide">
       <div class="${css.col1_1}">Gas Price</div>
-        <input type="number" class="${css.col2}" id="gasPrice" value="0">
+        <input type="number" class="${css.col2}" id="gasPrice" value="0" title="Not implemented yet, just ignore (gas price is set to 1), so the current gas price from the network will be taken.">
       </div>
       <div class="${css.crow}">
       <div class="${css.col1_1}">Value</div>


### PR DESCRIPTION
This fixes a critical bug using ``Ether`` as a base unit for the value input field in the ``Run`` tab, which could in combination without warning / extra hint lead to people loosing thousands of dollars.

Beside from that there is some extra context help texts added to ``Run`` tab input elements.