### PR TITLE
Default to JavaScript VM even with injected Web3

### DIFF
--- a/src/execution-context.js
+++ b/src/execution-context.js
@@ -80,7 +80,7 @@ web3VM.setVM(vm)
 function ExecutionContext () {
   var self = this
   this.event = new EventManager()
-  var executionContext = injectedProvider ? 'injected' : 'vm'
+  var executionContext = 'vm'
 
   this.getProvider = function () {
     return executionContext


### PR DESCRIPTION
I have MetaMask installed in Chrome so I always have to first change the Environment option to use the features in the Run tab. Since the biggest use case for Remix right now is to quickly try out some code, especially for beginners, I find the current behavior annoying.

I discussed this at DEVCON with fellow developers and most of them agreed with it, though I am open to hearing alternative points of view.