### PR TITLE
Fix TypeError when using older solc

### DIFF
--- a/src/recorder.js
+++ b/src/recorder.js
@@ -41,7 +41,7 @@ class Recorder {
             record.contractName = payLoad.contractName
             record.bytecode = payLoad.contractBytecode
             record.linkReferences = selectedContract.object.evm.bytecode.linkReferences
-            if (Object.keys(record.linkReferences).length) {
+            if (record.linkReferences && Object.keys(record.linkReferences).length) {
               for (var file in record.linkReferences) {
                 for (var lib in record.linkReferences[file]) {
                   self.data._linkReferences[lib] = '<address>'


### PR DESCRIPTION
Fixes #967.

On solc 0.4.10 or earlier, `linkReferences` is undefined.  Without this change, you can compile contracts against old solidity compilers, but you can't create them in the IDE.