### PR TITLE
Fix readonly file on remixd

### DIFF
--- a/src/app/files/shared-folder.js
+++ b/src/app/files/shared-folder.js
@@ -145,8 +145,7 @@ module.exports = class SharedFolder {
   }
 
   isReadOnly (path) {
-    if (this.files) return this.files[path]
-    return true
+    return false // TODO: add a callback here to allow calling remixd
   }
 
   remove (path) {

--- a/src/app/files/shared-folder.js
+++ b/src/app/files/shared-folder.js
@@ -12,6 +12,7 @@ function buildList (self, path = '', callback) {
     if (!counter) callback(null, fileTree)
     for (var i = 0, name, len = counter; i < len; i++) {
       name = list[i]
+      self.files[path] = path
       if (filesList[name].isDirectory) {
         setFolder(self, path, name, fileTree, finish)
       } else {
@@ -56,6 +57,7 @@ module.exports = class SharedFolder {
     this.error = { 'EEXIST': 'File already exists' }
     this._isReady = false
     this.filesContent = {}
+    this.files = {}
 
     remixd.event.register('notified', (data) => {
       if (data.scope === 'sharedfolder') {


### PR DESCRIPTION
this is a workaround for a bug that appear during the current file explorer refactor. 
that stuff should be removed in the future. @serapath 