### PR TITLE
the dependecy of the version of jquery updated 2.2.0 -> 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fast-levenshtein": "^2.0.6",
     "http-server": "0.9.0",
     "javascript-serialize": "^1.6.1",
-    "jquery": "^2.2.0",
+    "jquery": "^3.0.0",
     "js-base64": "^2.1.9",
     "js-beautify": "1.6.14",
     "minixhr": "^3.2.2",


### PR DESCRIPTION
When I pushed the browser-solidity to use local, github pointed out the security of vulnerability about the version of jquery and dependency.

' One of your dependencies may have a security vulnerability'
'Known moderate severity security vulnerability detected in jquery < 3.0.0defined in package.json.
package.json update suggested: jquery ~> 3.0.0.'