### PR TITLE
Add target="_blank" to support tab links, so they open in a new tab. Closes #998

### DIFF
--- a/src/app/tabs/support-tab.js
+++ b/src/app/tabs/support-tab.js
@@ -59,9 +59,9 @@ var css = csjs`
 var infoText = yo`
   <div>
     Have a question, found a bug or want to propose a feature? Have a look at the
-    <a href='https://github.com/ethereum/browser-solidity/issues'> issues</a> or check out
-    <a href='https://remix.readthedocs.io/en/latest/'> the documentation page on Remix</a> or
-    <a href='https://solidity.readthedocs.io/en/latest/'> Solidity</a>.
+    <a target="_blank" href='https://github.com/ethereum/browser-solidity/issues'> issues</a> or check out
+    <a target="_blank" href='https://remix.readthedocs.io/en/latest/'> the documentation page on Remix</a> or
+    <a target="_blank" href='https://solidity.readthedocs.io/en/latest/'> Solidity</a>.
   </div>
 `
 


### PR DESCRIPTION
Enhances user experience by opening support links in a new tab.