### PR TITLE
Edit the broken link on readme file for remix documentation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ After that, follow these steps:
 
 ## Documentation
 
-To see details about how to use Remix for developing and/or debugging Solidity contracts, please see [our documentation page](https://github.com/ethereum/remix)
+To see details about how to use Remix for developing and/or debugging Solidity contracts, please see [our documentation page](https://remix.readthedocs.io)

--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ After that, follow these steps:
 
 ## Documentation
 
-To see details about how to use Remix for developing and/or debugging Solidity contracts, please see [our documentation page]().
+To see details about how to use Remix for developing and/or debugging Solidity contracts, please see [our documentation page](https://github.com/ethereum/remix)


### PR DESCRIPTION
Link is broken to There is no documentation on the current repo for 'how to use Remix for developing and/or debugging Solidity contract' so created link to the actual remix repo that contains docs on getting started with remix. .

<img width="875" alt="screen shot 2018-02-05 at 4 04 38 pm" src="https://user-images.githubusercontent.com/13405531/35835259-788c7d3c-0a8e-11e8-8e21-0092bccd2724.png">

